### PR TITLE
Image gen

### DIFF
--- a/frontend/app/api/generate-image/route.ts
+++ b/frontend/app/api/generate-image/route.ts
@@ -1,0 +1,160 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { supabase } from "@/lib/supabase";
+import { rateLimit, getClientId } from "@/lib/rate-limit";
+import { generateImage, buildPrompt, hashPrompt } from "@/lib/replicate";
+
+// Stricter rate limit for image generation: 5 per hour
+const RATE_LIMIT = { limit: 5, windowMs: 60 * 60 * 1000 };
+
+export async function POST(req: Request) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Sign in to generate images" }, { status: 401 });
+    }
+
+    const clientId = getClientId(req);
+    const rateLimitResult = rateLimit(`generate-image:${userId}:${clientId}`, RATE_LIMIT);
+    if (!rateLimitResult.success) {
+      const minutesRemaining = Math.ceil(rateLimitResult.resetIn / 60000);
+      return NextResponse.json(
+        { error: `Rate limit reached. Try again in ${minutesRemaining} minutes.` },
+        { status: 429 }
+      );
+    }
+
+    if (!supabase) {
+      return NextResponse.json({ error: "Database not configured" }, { status: 503 });
+    }
+
+    const body = await req.json();
+    const { chapter, verse, translation } = body;
+
+    if (!chapter || !verse || !translation) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    // Build prompt and check cache
+    const prompt = buildPrompt(translation);
+    const promptHash = hashPrompt(prompt);
+
+    // Check if we already have this image cached
+    const { data: existingImage } = await supabase
+      .from("verse_images")
+      .select("*")
+      .eq("chapter", chapter)
+      .eq("verse", verse)
+      .eq("prompt_hash", promptHash)
+      .single();
+
+    if (existingImage) {
+      // Return cached image
+      return NextResponse.json({
+        imageUrl: existingImage.image_url,
+        shareUrl: `${process.env.NEXT_PUBLIC_APP_URL || ""}/image/${existingImage.id}`,
+        cached: true,
+      });
+    }
+
+    // Generate new image
+    const replicateImageUrl = await generateImage(prompt);
+
+    // Download the image from Replicate
+    const imageResponse = await fetch(replicateImageUrl);
+    if (!imageResponse.ok) {
+      throw new Error("Failed to download generated image");
+    }
+    const imageBlob = await imageResponse.blob();
+    const imageBuffer = await imageBlob.arrayBuffer();
+
+    // Upload to Supabase Storage
+    const storagePath = `verse-images/${chapter}-${verse}-${promptHash}.webp`;
+    const { error: uploadError } = await supabase.storage
+      .from("verse-images")
+      .upload(storagePath, imageBuffer, {
+        contentType: "image/webp",
+        upsert: true,
+      });
+
+    if (uploadError) {
+      console.error("Storage upload error:", uploadError);
+      throw new Error("Failed to store image");
+    }
+
+    // Get the public URL
+    const { data: publicUrlData } = supabase.storage
+      .from("verse-images")
+      .getPublicUrl(storagePath);
+
+    const publicImageUrl = publicUrlData.publicUrl;
+
+    // Save metadata to database
+    const { data: savedImage, error: insertError } = await supabase
+      .from("verse_images")
+      .insert({
+        chapter,
+        verse,
+        image_url: publicImageUrl,
+        storage_path: storagePath,
+        prompt_hash: promptHash,
+        user_id: userId,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      console.error("Database insert error:", insertError);
+      throw new Error("Failed to save image metadata");
+    }
+
+    return NextResponse.json({
+      imageUrl: publicImageUrl,
+      shareUrl: `${process.env.NEXT_PUBLIC_APP_URL || ""}/image/${savedImage.id}`,
+      cached: false,
+    });
+  } catch (error) {
+    console.error("Image generation error:", error);
+    const message = error instanceof Error ? error.message : "Failed to generate image";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// GET endpoint to fetch existing image for a verse
+export async function GET(req: Request) {
+  try {
+    if (!supabase) {
+      return NextResponse.json({ error: "Database not configured" }, { status: 503 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const chapter = searchParams.get("chapter");
+    const verse = searchParams.get("verse");
+
+    if (!chapter || !verse) {
+      return NextResponse.json({ error: "Missing chapter or verse" }, { status: 400 });
+    }
+
+    // Get the most recent image for this verse
+    const { data: existingImage } = await supabase
+      .from("verse_images")
+      .select("*")
+      .eq("chapter", parseInt(chapter))
+      .eq("verse", parseInt(verse))
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .single();
+
+    if (!existingImage) {
+      return NextResponse.json({ exists: false });
+    }
+
+    return NextResponse.json({
+      exists: true,
+      imageUrl: existingImage.image_url,
+      shareUrl: `${process.env.NEXT_PUBLIC_APP_URL || ""}/image/${existingImage.id}`,
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to check for existing image" }, { status: 500 });
+  }
+}

--- a/frontend/app/components/ImageModal.tsx
+++ b/frontend/app/components/ImageModal.tsx
@@ -1,0 +1,165 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { X, Download, Link, Check } from "lucide-react";
+
+interface ImageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imageUrl: string;
+  shareUrl: string;
+  chapter: number;
+  verse: number;
+}
+
+export function ImageModal({
+  isOpen,
+  onClose,
+  imageUrl,
+  shareUrl,
+  chapter,
+  verse,
+}: ImageModalProps) {
+  const [copied, setCopied] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    if (isOpen) {
+      window.addEventListener("keydown", handleEscape);
+    }
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !mounted) return null;
+
+  const handleDownload = async () => {
+    try {
+      // Load image and convert to PNG
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = reject;
+        img.src = imageUrl;
+      });
+
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Could not get canvas context");
+      ctx.drawImage(img, 0, 0);
+
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, "image/png")
+      );
+      if (!blob) throw new Error("Could not create PNG blob");
+
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `gita-${chapter}-${verse}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Download failed:", error);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("Copy failed:", error);
+    }
+  };
+
+  const modalContent = (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/90 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal content */}
+      <div className="relative z-10 mx-4 flex max-h-[90vh] w-full max-w-4xl flex-col">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <span className="font-sans text-sm tracking-wide text-white/70">
+            Chapter {chapter}, Verse {verse}
+          </span>
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Image */}
+        <div className="relative overflow-hidden rounded-lg bg-black/50">
+          <img
+            src={imageUrl}
+            alt={`Bhagavad Gita Chapter ${chapter}, Verse ${verse} - Anime Visualization`}
+            className="h-auto w-full object-contain"
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="mt-4 flex items-center justify-center gap-4">
+          <button
+            onClick={handleDownload}
+            className="flex items-center gap-2 rounded-full bg-saffron px-6 py-2.5 font-sans text-sm font-medium tracking-wide text-white transition-opacity hover:opacity-90"
+          >
+            <Download className="h-4 w-4" />
+            Download
+          </button>
+          <button
+            onClick={handleCopyLink}
+            className="flex items-center gap-2 rounded-full border border-white/20 px-6 py-2.5 font-sans text-sm tracking-wide text-white/80 transition-colors hover:border-white/40 hover:text-white"
+          >
+            {copied ? (
+              <>
+                <Check className="h-4 w-4" />
+                Copied!
+              </>
+            ) : (
+              <>
+                <Link className="h-4 w-4" />
+                Copy Link
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}

--- a/frontend/app/image/[id]/DownloadPngButton.tsx
+++ b/frontend/app/image/[id]/DownloadPngButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Download } from "lucide-react";
+
+interface DownloadPngButtonProps {
+  imageUrl: string;
+  chapter: number;
+  verse: number;
+}
+
+export function DownloadPngButton({ imageUrl, chapter, verse }: DownloadPngButtonProps) {
+  const handleDownload = async () => {
+    try {
+      // Load image and convert to PNG
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = reject;
+        img.src = imageUrl;
+      });
+
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Could not get canvas context");
+      ctx.drawImage(img, 0, 0);
+
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, "image/png")
+      );
+      if (!blob) throw new Error("Could not create PNG blob");
+
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `gita-${chapter}-${verse}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Download failed:", error);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleDownload}
+      className="flex items-center gap-2 bg-saffron px-6 py-2.5 font-sans text-sm font-medium tracking-wide text-white transition-opacity hover:opacity-90"
+    >
+      <Download className="h-4 w-4" />
+      Download
+    </button>
+  );
+}

--- a/frontend/app/image/[id]/page.tsx
+++ b/frontend/app/image/[id]/page.tsx
@@ -1,0 +1,117 @@
+/* eslint-disable @next/next/no-img-element */
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { supabase, VerseImage } from "@/lib/supabase";
+import Link from "next/link";
+import { DownloadPngButton } from "./DownloadPngButton";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function getImage(id: string): Promise<VerseImage | null> {
+  if (!supabase) return null;
+
+  const { data, error } = await supabase
+    .from("verse_images")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error || !data) return null;
+  return data;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const image = await getImage(id);
+
+  if (!image) {
+    return { title: "Image Not Found - GitaChat" };
+  }
+
+  return {
+    title: `Bhagavad Gita ${image.chapter}:${image.verse} - Visualization - GitaChat`,
+    description: `Anime visualization of Bhagavad Gita Chapter ${image.chapter}, Verse ${image.verse}`,
+    openGraph: {
+      title: `Bhagavad Gita ${image.chapter}:${image.verse} Visualization`,
+      description: `Anime-style illustration inspired by the Bhagavad Gita`,
+      images: [
+        {
+          url: image.image_url,
+          width: 1280,
+          height: 720,
+          alt: `Bhagavad Gita Chapter ${image.chapter}, Verse ${image.verse}`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `Bhagavad Gita ${image.chapter}:${image.verse} Visualization`,
+      description: `Anime-style illustration inspired by the Bhagavad Gita`,
+      images: [image.image_url],
+    },
+  };
+}
+
+export default async function ImagePage({ params }: PageProps) {
+  const { id } = await params;
+  const image = await getImage(id);
+
+  if (!image) {
+    notFound();
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gradient-to-b from-background via-background to-[hsl(25_20%_6%)]">
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-6 pt-12 sm:px-10 sm:pt-16 md:px-12">
+        {/* Back link */}
+        <Link
+          href={`/verse/${image.chapter}/${image.verse}`}
+          className="mb-8 inline-block font-sans text-sm tracking-wide text-muted-foreground/60 transition-colors hover:text-foreground"
+        >
+          ← View verse
+        </Link>
+
+        {/* Chapter/Verse badge */}
+        <div className="mb-6 inline-block self-start bg-saffron-light px-4 py-2">
+          <span className="font-sans text-sm font-medium tracking-wide text-saffron">
+            Chapter {image.chapter}, Verse {image.verse}
+          </span>
+        </div>
+
+        {/* Image */}
+        <div className="overflow-hidden rounded-lg bg-black/20">
+          <img
+            src={image.image_url}
+            alt={`Bhagavad Gita Chapter ${image.chapter}, Verse ${image.verse} - Anime Visualization`}
+            className="h-auto w-full object-contain"
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="mt-6 flex items-center gap-4">
+          <DownloadPngButton
+            imageUrl={image.image_url}
+            chapter={image.chapter}
+            verse={image.verse}
+          />
+          <Link
+            href={`/verse/${image.chapter}/${image.verse}`}
+            className="border border-border/40 px-6 py-2.5 font-sans text-sm tracking-wide text-muted-foreground/80 transition-colors hover:border-saffron/40 hover:text-foreground"
+          >
+            Read Verse
+          </Link>
+        </div>
+
+        {/* Footer */}
+        <footer className="mt-auto pb-8 pt-20">
+          <div className="mb-6 h-px w-12 bg-border/20" />
+          <p className="font-sans text-xs tracking-wider text-muted-foreground/40">
+            Created with GitaChat
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/lib/replicate.ts
+++ b/frontend/app/lib/replicate.ts
@@ -1,0 +1,100 @@
+const REPLICATE_API_TOKEN = process.env.REPLICATE_API_TOKEN;
+const REPLICATE_API_URL = "https://api.replicate.com/v1";
+
+export interface ReplicateOutput {
+  imageUrl: string;
+}
+
+export function buildPrompt(translation: string): string {
+  // Extract key themes from the verse for the prompt
+  const basePrompt = `anime style illustration, Bhagavad Gita scene, spiritual atmosphere, divine golden light, Krishna and Arjuna, battlefield of Kurukshetra, Indian mythology, studio ghibli inspired, warm golden and saffron tones, high quality anime art, masterpiece, ethereal atmosphere`;
+
+  // Include a condensed version of the translation for context
+  const condensedTranslation = translation.slice(0, 200);
+
+  return `${basePrompt}, depicting: ${condensedTranslation}`;
+}
+
+export function hashPrompt(prompt: string): string {
+  // Simple hash function for prompt caching
+  let hash = 0;
+  for (let i = 0; i < prompt.length; i++) {
+    const char = prompt.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return Math.abs(hash).toString(16);
+}
+
+export async function generateImage(prompt: string): Promise<string> {
+  if (!REPLICATE_API_TOKEN) {
+    throw new Error("REPLICATE_API_TOKEN is not configured");
+  }
+
+  // Use flux-schnell for fast generation
+  const response = await fetch(`${REPLICATE_API_URL}/models/black-forest-labs/flux-schnell/predictions`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${REPLICATE_API_TOKEN}`,
+      "Content-Type": "application/json",
+      "Prefer": "wait", // Wait for the result synchronously
+    },
+    body: JSON.stringify({
+      input: {
+        prompt,
+        num_outputs: 1,
+        aspect_ratio: "16:9",
+        output_format: "webp",
+        output_quality: 90,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Replicate API error: ${error}`);
+  }
+
+  const result = await response.json();
+
+  // Handle different response formats
+  if (result.output && Array.isArray(result.output) && result.output.length > 0) {
+    return result.output[0];
+  }
+
+  if (result.urls?.get) {
+    // If we need to poll for the result
+    return await pollForResult(result.urls.get);
+  }
+
+  throw new Error("Unexpected Replicate API response format");
+}
+
+async function pollForResult(getUrl: string, maxAttempts = 60): Promise<string> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await fetch(getUrl, {
+      headers: {
+        "Authorization": `Bearer ${REPLICATE_API_TOKEN}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to poll Replicate API");
+    }
+
+    const result = await response.json();
+
+    if (result.status === "succeeded" && result.output) {
+      return Array.isArray(result.output) ? result.output[0] : result.output;
+    }
+
+    if (result.status === "failed") {
+      throw new Error(result.error || "Image generation failed");
+    }
+
+    // Wait 1 second before polling again
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  throw new Error("Image generation timed out");
+}

--- a/frontend/app/lib/supabase.ts
+++ b/frontend/app/lib/supabase.ts
@@ -30,3 +30,14 @@ export interface EmailSubscriber {
   subscribed_at: string;
   created_at: string;
 }
+
+export interface VerseImage {
+  id: string;
+  chapter: number;
+  verse: number;
+  image_url: string;
+  storage_path: string;
+  prompt_hash: string;
+  user_id: string | null;
+  created_at: string;
+}

--- a/frontend/app/verse/[chapter]/[verse]/page.tsx
+++ b/frontend/app/verse/[chapter]/[verse]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { VerseActions } from "@/components/VerseActions";
 
 interface VerseData {
   chapter: number;
@@ -106,6 +107,15 @@ export default async function VersePage({
             <p className="text-base leading-loose tracking-wide text-foreground/70 sm:text-lg">
               {verse.summarized_commentary}
             </p>
+          </div>
+
+          <div className="mt-10">
+            <VerseActions
+              chapter={verse.chapter}
+              verse={verse.verse}
+              translation={verse.translation}
+              summarized_commentary={verse.summarized_commentary}
+            />
           </div>
         </article>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "next": "^15.5.9",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "replicate": "^1.4.0",
         "resend": "^6.7.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7"
@@ -1765,6 +1766,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "dev": true,
@@ -2034,7 +2048,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2094,7 +2108,7 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3069,6 +3083,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "7.2.0",
       "dev": true,
@@ -3577,7 +3611,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5090,6 +5124,16 @@
         }
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "dev": true,
@@ -5229,6 +5273,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/replicate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-1.4.0.tgz",
+      "integrity": "sha512-1ufKejfUVz/azy+5TnzQP7U1+MHVWZ6psnQ06az8byUUnRhT+DZ/MvewzB1NQYBVMgNKR7xPDtTwlcP5nv/5+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      },
+      "optionalDependencies": {
+        "readable-stream": ">=4.0.0"
+      }
+    },
+    "node_modules/replicate/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/resend": {
@@ -5400,7 +5476,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5621,7 +5697,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7315,6 +7391,15 @@
       "version": "1.2.0",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "8.14.0",
       "dev": true
@@ -7477,7 +7562,7 @@
     },
     "base64-js": {
       "version": "1.5.1",
-      "dev": true
+      "devOptional": true
     },
     "binary-extensions": {
       "version": "2.3.0"
@@ -7509,7 +7594,7 @@
     },
     "buffer": {
       "version": "6.0.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -8125,6 +8210,18 @@
       "version": "2.0.3",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "optional": true
+    },
     "execa": {
       "version": "7.2.0",
       "dev": true,
@@ -8431,7 +8528,7 @@
     },
     "ieee754": {
       "version": "1.2.1",
-      "dev": true
+      "devOptional": true
     },
     "ignore": {
       "version": "5.3.2",
@@ -9180,6 +9277,12 @@
       "dev": true,
       "requires": {}
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "optional": true
+    },
     "prompts": {
       "version": "2.4.2",
       "dev": true,
@@ -9263,6 +9366,29 @@
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
         "set-function-name": "^2.0.2"
+      }
+    },
+    "replicate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-1.4.0.tgz",
+      "integrity": "sha512-1ufKejfUVz/azy+5TnzQP7U1+MHVWZ6psnQ06az8byUUnRhT+DZ/MvewzB1NQYBVMgNKR7xPDtTwlcP5nv/5+w==",
+      "requires": {
+        "readable-stream": ">=4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+          "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+          "optional": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        }
       }
     },
     "resend": {
@@ -9354,7 +9480,7 @@
     },
     "safe-buffer": {
       "version": "5.2.1",
-      "dev": true
+      "devOptional": true
     },
     "safe-regex-test": {
       "version": "1.0.3",
@@ -9497,7 +9623,7 @@
     },
     "string_decoder": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "next": "^15.5.9",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "replicate": "^1.4.0",
     "resend": "^6.7.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces end-to-end verse visualization with rate-limited image generation, caching, storage, and sharing.
> 
> - New `POST /api/generate-image` uses Replicate (`flux-schnell`) to create images, caches by `prompt_hash`, uploads to Supabase Storage, saves `verse_images` metadata, and returns a share URL; `GET /api/generate-image` fetches latest existing image for a verse
> - Adds `lib/replicate` (prompt builder, prompt hashing, generate + polling) and `VerseImage` type in `lib/supabase`
> - Updates `VerseActions` to include "Visualize" flow using React Query mutation, with `ImageModal` for viewing, copying link, and PNG download
> - New image detail page `app/image/[id]` with SEO metadata, full image view, and `DownloadPngButton` (client-side PNG conversion); includes link back to verse
> - Dependency: adds `replicate`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3472e93e4105dd7c9105830479e25c1edb1904ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->